### PR TITLE
Ignore relationships that don't have data property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import {
   concat,
   insert,
   assocPath,
-  pickBy
+  pickBy,
 } from 'ramda';
 import { mapIndexed, reduceIndexed, ensureArray, isArray } from 'ramda-adjunct';
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import {
   concat,
   insert,
   assocPath,
+  pickBy
 } from 'ramda';
 import { mapIndexed, reduceIndexed, ensureArray, isArray } from 'ramda-adjunct';
 
@@ -24,7 +25,7 @@ import { mapIndexed, reduceIndexed, ensureArray, isArray } from 'ramda-adjunct';
 //     RelPath = {path: String, key: ResourceKey}
 
 // getRelationships :: Resource -> Relationships
-const getRelationships = pipe(propOr({}, ['relationships']), keys);
+const getRelationships = pipe(propOr({}, ['relationships']), pickBy(has('data')), keys);
 
 // resourceKey :: ResourceRel -> ResourceKey
 const resourceKey = ({ type, id }) => `${type}-${id}`;

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,11 @@ import { mapIndexed, reduceIndexed, ensureArray, isArray } from 'ramda-adjunct';
 //     RelPath = {path: String, key: ResourceKey}
 
 // getRelationships :: Resource -> Relationships
-const getRelationships = pipe(propOr({}, ['relationships']), pickBy(has('data')), keys);
+const getRelationships = pipe(
+  propOr({}, ['relationships']),
+  pickBy(has('data')),
+  keys
+);
 
 // resourceKey :: ResourceRel -> ResourceKey
 const resourceKey = ({ type, id }) => `${type}-${id}`;

--- a/test/index.js
+++ b/test/index.js
@@ -763,10 +763,27 @@ describe('jsonApiMerge', function () {
     };
 
     specify('should throw error', function () {
-      const included = jsonApiMerge(jsonApiData.included, jsonApiData.included);
-      const thunk = () => jsonApiMerge(included, jsonApiData.data);
+      const expected = {
+        id: 1,
+        type: 'resource',
+        attributes: {
+          name: 'Resource name',
+        },
+        relationships: {
+          related: {
+            links: {
+              related: {
+                href: 'http://example.com/related-resource/',
+                title: 'Related',
+              },
+            },
+          },
+        },
+      };
 
-      assert.throws(thunk, TypeError);
+      const actual = jsonApiMerge(jsonApiData.included, jsonApiData.data);
+
+      assert.deepEqual(actual, expected);
     });
   });
 


### PR DESCRIPTION
I'm using json-api-merge on a request that only has some relationships included, so I have data that looks like this:

```json
  "relationships": {
    "validation_messages": {
      "links": {
        "related": "[/api/filings/5877/validation_messages](http://localhost:5000/api/filings/5877/validation_messages)"
      }
    },
    "entity": {
      "links": {
        "related": "[/api/entities/213800XB8YZNGJYDEZ97](http://localhost:5000/api/entities/213800XB8YZNGJYDEZ97)"
      },
      "data": {
        "type": "entity",
        "id": "1331"
      }
    }
  }
```

Note the lack of `data` property on `validation_messages`.  json-api-merge currently breaks on this input.  This PR filters relationships to those which contain the `data` property.