### PR TITLE
Cope with null relationships

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import {
   insert,
   assocPath,
   pickBy,
+  propSatisfies,
 } from 'ramda';
 import { mapIndexed, reduceIndexed, ensureArray, isArray } from 'ramda-adjunct';
 
@@ -28,6 +29,7 @@ import { mapIndexed, reduceIndexed, ensureArray, isArray } from 'ramda-adjunct';
 const getRelationships = pipe(
   propOr({}, ['relationships']),
   pickBy(has('data')),
+  pickBy(propSatisfies(x => x !== null, 'data')),
   keys
 );
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ import { mapIndexed, reduceIndexed, ensureArray, isArray } from 'ramda-adjunct';
 const getRelationships = pipe(
   propOr({}, ['relationships']),
   pickBy(has('data')),
-  pickBy(propSatisfies(x => x !== null, 'data')),
+  pickBy(propSatisfies((x) => x !== null, 'data')),
   keys
 );
 


### PR DESCRIPTION
I have some data with a nullable relationship.  This results in API data like this:

```json
{
    "relationships": {
        "language": {
            "data": null
        }
    }
}
```

This is valid according to the [JSON API spec](https://jsonapi.org/format/#document-resource-object-linkage), but was causing an exception in `json-api-merge` when trying to resolve this relationship.  This PR fixes this, although perhaps there is a more elegant way to do this not-null check in Ramda?